### PR TITLE
add default function to formats prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,9 @@ export default {
     */
     formats: {
       type: Array,
-      default: []
+      default () {
+        return []
+      }
     },
     /**
      * Whether to start the playback


### PR DESCRIPTION
Hi there, thanks for the nice mixin ! I just started to use it and got vue complaining about the format props, so I just changed the default empty array into a factory function returning an empty array.